### PR TITLE
[Feature] Cypress의 screenshots 폴더를 gitignore에 포함합니다 (이슈 #22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules
 ## Jest
 coverage
 
+# Cypress
+cypress/screenshots
+
 ## Build
 dist
 build


### PR DESCRIPTION
# Cypress의 screenshots 폴더를 gitignore에 포함합니다
## 구현
- [x] Cypress의 screenshots 폴더를 gitignore에 포함

## 이슈
- [x] 없음

## 참조
- #22
