### PR TITLE
[Bug] 잘못된 수유 저장 형식을 고칩니다 (이슈 #41)

### DIFF
--- a/src/redux/lactation/interaction.ts
+++ b/src/redux/lactation/interaction.ts
@@ -60,8 +60,8 @@ export const saveLactation = () => (
   const { interaction } = getState();
   dispatch(unshiftRecord(interaction));
 
-  const { record } = getState();
-  saveItem({ key: 'record', value: JSON.stringify(record) });
+  const { record: { records } } = getState();
+  saveItem({ key: 'record', value: JSON.stringify(records) });
 
   dispatch(actions.clearInteraction());
 };


### PR DESCRIPTION
# 잘못된 수유 저장 형식을 고칩니다
## 구현
- [x] localStorage 저장 형식을 올바르게 수정

## 이슈
- [x] 작업 중 발견한 이슈를 고칩니다 (#40)

## 참조
- #41 
