### PR TITLE
[Bug] 하임리히 프로젝트를 배포 오류를 고칩니다 (이슈 #54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "cypress": "cypress open",
     "cypress:headless": "cypress run",
     "e2e": "start-server-and-test dev http://localhost:3000 cypress",
-    "e2e:headless": "start-server-and-test dev http://localhost:3000 cypress:headless",
-    "deploy:netlify": "next build && next export"
+    "e2e:headless": "start-server-and-test dev http://localhost:3000 cypress:headless"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.7.1",


### PR DESCRIPTION
# 하임리히 프로젝트를 배포 오류를 고칩니다
## 구현
- [x] 배포 시스템 변경(netlify -> vercel)에 따른 스크립트 삭제

## 이슈
- [x] 없음

## 참조
- #54 
